### PR TITLE
Feature - Hit Sense Debounce

### DIFF
--- a/BMG-Stop-Plate/platformio.ini
+++ b/BMG-Stop-Plate/platformio.ini
@@ -12,8 +12,8 @@
 platform = atmelavr
 board = nanoatmega328
 framework = arduino
-upload_port = COM6
-debug_port = COM6
+upload_port = COM3
+debug_port = COM3
 lib_deps = 
 	fastled/FastLED@^3.4.0
 	greiman/SSD1306Ascii@^1.3.1

--- a/BMG-Stop-Plate/src/main.cpp
+++ b/BMG-Stop-Plate/src/main.cpp
@@ -73,6 +73,8 @@
   int SENSITIVITY_INTERALS = 5;
   int CURRENT_SENSITIVITY = 100;
   int MAX_SENSITIVITY = 200; 
+  int POST_HIT_SENSE_DELAY = 200;
+  int POST_START_SENSE_DELAY = 1000;
 
   int BUZZER_TIME = 750;
 
@@ -343,6 +345,9 @@
     START_TIME = millis();
     SoundBuzzer();
     TIME_RECORDED = false;
+
+    // Set Start Timing Delay
+    delay(POST_START_SENSE_DELAY);
   }
 
   void ShowReview() {
@@ -429,6 +434,9 @@
     Serial.println();
 
     DisplayTimeRecorded(hitNo, seconds, centiSecond);
+
+    // Set Hit Sense Delay
+    delay(POST_HIT_SENSE_DELAY);
   }
 
   void CheckStopPlateHit() {


### PR DESCRIPTION
Present a short term hack, to stop the hit sensor from detecting false hits from the much more sensitive sensor.