### PR TITLE
Create a Sensitivity Offset for Piezo Sensor

### DIFF
--- a/BMG-Stop-Plate/src/main.cpp
+++ b/BMG-Stop-Plate/src/main.cpp
@@ -70,9 +70,10 @@
   uint8_t HIT_MEMORY_CURSOR = 0;
   uint8_t HIT_COUNT = 0;
 
-  int SENSITIVITY_INTERALS = 5;
-  int CURRENT_SENSITIVITY = 100;
-  int MAX_SENSITIVITY = 200; 
+  int OFFSET_SENSITIVITY = 60;
+  int SENSITIVITY_INTERALS = 10;
+  int CURRENT_SENSITIVITY = 200;
+  int MAX_SENSITIVITY = 400; 
 
   int BUZZER_TIME = 750;
 
@@ -384,17 +385,23 @@
   }
 
   void SetSensitivityUp() {
-    if (CURRENT_SENSITIVITY == SENSITIVITY_INTERALS)
+    if (CURRENT_SENSITIVITY <= SENSITIVITY_INTERALS)
       return;
 
     CURRENT_SENSITIVITY -= SENSITIVITY_INTERALS;
+
+    Serial.print("Sense Up | ");
+    Serial.println(CURRENT_SENSITIVITY + OFFSET_SENSITIVITY);
   }
 
   void SetSensitivityDwn() {
-    if (CURRENT_SENSITIVITY == MAX_SENSITIVITY)
+    if (CURRENT_SENSITIVITY >= MAX_SENSITIVITY)
       return;
 
     CURRENT_SENSITIVITY += SENSITIVITY_INTERALS;
+
+    Serial.print("Sense Dwn | ");
+    Serial.println(CURRENT_SENSITIVITY + OFFSET_SENSITIVITY);
   }
 
   void RecordStopPlateHit() {
@@ -435,7 +442,7 @@
     Serial.print("Sensor: ");
     int piezoSensor = analogRead(IO_Sensor);    
     Serial.print(piezoSensor);
-    if (piezoSensor >= CURRENT_SENSITIVITY) {
+    if (piezoSensor >= (CURRENT_SENSITIVITY + OFFSET_SENSITIVITY)) {
       RecordStopPlateHit();
       Serial.print(" HIT REGISTERED");
     }


### PR DESCRIPTION
Creating an offset value to use when calculating the threshold for a hit to be registered. Does not effect the actual value set by the user and is calculated only when checking the live value to the set sensitivity.

HIT RECORDED IF
      SENSOR_VALUE > (USERSET_THRESHOLD + OFFSET_SENSITIVITY)