### PR TITLE
Add delayer when hit detected on sensor

### DIFF
--- a/BMG-Stop-Plate/src/main.cpp
+++ b/BMG-Stop-Plate/src/main.cpp
@@ -75,6 +75,8 @@
   int CURRENT_SENSITIVITY = 200;
   int MAX_SENSITIVITY = 400; 
 
+  int HIT_SENSOR_DELAY = 200;
+
   int BUZZER_TIME = 750;
 
   bool LED_HIT_STAGE;
@@ -436,6 +438,8 @@
     Serial.println();
 
     DisplayTimeRecorded(hitNo, seconds, centiSecond);
+
+    delay(HIT_SENSOR_DELAY);
   }
 
   void CheckStopPlateHit() {


### PR DESCRIPTION
Added a delay after recording a hit which should stop the processor from recording further resonating hits within a 200 ms threshold. 